### PR TITLE
feat: add decorator to fetch hasura claims easily

### DIFF
--- a/src/hasura/hasura.decorator.ts
+++ b/src/hasura/hasura.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const HasuraClaims = createParamDecorator((data: string, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest();
+  const user = request.user;
+
+  return data ? user?.['https://hasura.io/jwt/claims'][data] : user?.['https://hasura.io/jwt/claims'];
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './hasura/hasura.decorator';
 export * from './hasura/hasura.module';
 export * from './hasura/hasura.service';


### PR DESCRIPTION
Add a decorator to fetch Hasura Claims easily. 

Example: 

```typescript
async someControllerFunction(@HasuraClaims('x-hasura-current-provider') provider: string) {}
```